### PR TITLE
feat: implement `nimbus build` command

### DIFF
--- a/include/constants/config_toml.hpp
+++ b/include/constants/config_toml.hpp
@@ -11,7 +11,7 @@ constexpr std::string_view ConfigFile = "nimbus.toml";
 
 // TODO: Automate using existing enum constants!
 /// Comment
-constexpr std::string_view getConfigFileDefaults() {
+constexpr std::string_view getConfigFileDefaults() noexcept {
   return "[project]\n"
          "name = \"{}\"\n"
          "version = \"0.1.0\"\n"
@@ -26,7 +26,7 @@ constexpr std::string_view getConfigFileDefaults() {
 enum class Table { Project, Build };
 
 /// Comment
-constexpr std::string_view toString(Table tbl) {
+constexpr std::string_view toString(Table tbl) noexcept {
   switch (tbl) {
   case Table::Project:
     return "project";
@@ -39,7 +39,7 @@ constexpr std::string_view toString(Table tbl) {
 enum class Key { Name, Version, Authors, Compiler, Standard, BuildType };
 
 /// Comment
-constexpr std::string_view toString(Key key) {
+constexpr std::string_view toString(Key key) noexcept {
   switch (key) {
   case Key::Name:
     return "name";

--- a/include/constants/config_toml.hpp
+++ b/include/constants/config_toml.hpp
@@ -1,16 +1,34 @@
-/// Comment
+/**
+ * @file config_toml.hpp
+ * @brief Defines constants and utility functions related to the project's
+ * `nimbus.toml` configuration file.
+ *
+ * This header provides constants, enums, and helper functions for interacting
+ * with the project's `nimbus.toml` file. It includes defaults for various
+ * configuration values and mappings from enum types to their string
+ * representations.
+ */
 
 #pragma once
 
 #include <string_view>
 
 namespace constants {
-
-/// Comment
+/**
+ * @brief The name of the project's configuration file.
+ */
 constexpr std::string_view ConfigFile = "nimbus.toml";
 
 // TODO: Automate using existing enum constants!
-/// Comment
+/**
+ * @brief Provides default contents for the `nimbus.toml` configuration file.
+ *
+ * Returns a TOML-formatted string that outlines default project metadata and
+ * build settings. This can be used when initializing a new project or when
+ * generating the configuration file if one does not exist.
+ *
+ * @return A `std::string_view` containing the default configuration text.
+ */
 constexpr std::string_view getConfigFileDefaults() noexcept {
   return "[project]\n"
          "name = \"{}\"\n"
@@ -22,10 +40,19 @@ constexpr std::string_view getConfigFileDefaults() noexcept {
          "build_type = \"Debug\"\n";
 }
 
-/// Comment
+/**
+ * @brief Enumerates the configuration sections (tables) within `nimbus.toml`.
+ */
 enum class Table { Project, Build };
 
-/// Comment
+/**
+ * @brief Converts a `Table` enumeration value to its corresponding string
+ * representation.
+ *
+ * @param tbl The `Table` enum value.
+ * @return A `std::string_view` that corresponds to the given table (e.g.,
+ * "project" or "build").
+ */
 constexpr std::string_view toString(Table tbl) noexcept {
   switch (tbl) {
   case Table::Project:
@@ -35,10 +62,20 @@ constexpr std::string_view toString(Table tbl) noexcept {
   }
 }
 
-/// Comment
+/**
+ * @brief Enumerates the keys used within each configuration table of
+ * `nimbus.toml`.
+ */
 enum class Key { Name, Version, Authors, Compiler, Standard, BuildType };
 
-/// Comment
+/**
+ * @brief Converts a `Key` enumeration value to its corresponding string
+ * representation.
+ *
+ * @param key The `Key` enum value.
+ * @return A `std::string_view` that corresponds to the given key (e.g., "name",
+ * "version").
+ */
 constexpr std::string_view toString(Key key) noexcept {
   switch (key) {
   case Key::Name:

--- a/include/constants/config_toml.hpp
+++ b/include/constants/config_toml.hpp
@@ -1,0 +1,58 @@
+/// Comment
+
+#pragma once
+
+#include <string_view>
+
+namespace constants {
+
+/// Comment
+constexpr std::string_view ConfigFile = "nimbus.toml";
+
+// TODO: Automate using existing enum constants!
+/// Comment
+constexpr std::string_view getConfigFileDefaults() {
+  return "[project]\n"
+         "name = \"{}\"\n"
+         "version = \"0.1.0\"\n"
+         "authors = [\"Your Name <you@example.com>\"]\n\n"
+         "[build]\n"
+         "compiler = \"clang++\"\n"
+         "standard = \"c++20\"\n"
+         "build_type = \"Debug\"\n";
+}
+
+/// Comment
+enum class Table { Project, Build };
+
+/// Comment
+constexpr std::string_view toString(Table tbl) {
+  switch (tbl) {
+  case Table::Project:
+    return "project";
+  case Table::Build:
+    return "build";
+  }
+}
+
+/// Comment
+enum class Key { Name, Version, Authors, Compiler, Standard, BuildType };
+
+/// Comment
+constexpr std::string_view toString(Key key) {
+  switch (key) {
+  case Key::Name:
+    return "name";
+  case Key::Version:
+    return "version";
+  case Key::Authors:
+    return "authors";
+  case Key::Compiler:
+    return "compiler";
+  case Key::Standard:
+    return "standard";
+  case Key::BuildType:
+    return "build_type";
+  }
+}
+} // namespace constants

--- a/include/constants/directory.hpp
+++ b/include/constants/directory.hpp
@@ -1,0 +1,25 @@
+/// Comment
+
+#pragma once
+
+#include <string_view>
+
+namespace constants {
+
+/// Comment
+enum class Directory { Current, Include, Src, Build };
+
+/// Comment
+constexpr std::string_view toString(Directory dir) {
+  switch (dir) {
+  case Directory::Current:
+    return ".";
+  case Directory::Include:
+    return "include";
+  case Directory::Src:
+    return "src";
+  case Directory::Build:
+    return "build";
+  }
+}
+} // namespace constants

--- a/include/constants/directory.hpp
+++ b/include/constants/directory.hpp
@@ -10,7 +10,7 @@ namespace constants {
 enum class Directory { Current, Include, Src, Build };
 
 /// Comment
-constexpr std::string_view toString(Directory dir) {
+constexpr std::string_view toString(Directory dir) noexcept {
   switch (dir) {
   case Directory::Current:
     return ".";

--- a/include/constants/directory.hpp
+++ b/include/constants/directory.hpp
@@ -1,15 +1,34 @@
-/// Comment
+/**
+ * @file directory.hpp
+ * @brief Defines directory-related constants and utilities.
+ *
+ * This header provides an enumeration for commonly used directory names
+ * within the project structure, as well as a function for converting these
+ * enum values to their corresponding string representations.
+ */
 
 #pragma once
 
 #include <string_view>
 
 namespace constants {
-
-/// Comment
+/**
+ * @brief Enumerates common directories used within the project's structure.
+ *
+ * These directories represent important locations within a typical C++ project,
+ * including the current directory, the `include` directory for headers, the
+ * `src` directory for source files, and a dedicated `build` directory.
+ */
 enum class Directory { Current, Include, Src, Build };
 
-/// Comment
+/**
+ * @brief Converts a `Directory` enumeration value to its corresponding string
+ * representation.
+ *
+ * @param dir The `Directory` enum value.
+ * @return A `std::string_view` containing the name of the directory (e.g., ".",
+ * "include", "src", or "build").
+ */
 constexpr std::string_view toString(Directory dir) noexcept {
   switch (dir) {
   case Directory::Current:

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -85,11 +85,14 @@ export void process() {
     return;
   }
 
+  // char due to '\' constexpr violation
+  constexpr char findSubcommand[] =
+      "$(find src -type f \\( -name \"*.cpp\" -o -name \"*.c\" -o -name "
+      "\"*.cxx\" \\))";
+
   const std::string command =
-      std::format("{} -std={} $(find src -type f \\( -name \"*.cpp\" -o -name "
-                  "\"*.c\" -o -name \"*.cxx\" \\)) -o {}/{}",
-                  compiler.value(), standard.value(), constants::BUILD_DIR,
-                  projectName.value());
+      std::format("{} -std={} {} -o {}/{}", compiler.value(), standard.value(),
+                  findSubcommand, constants::BUILD_DIR, projectName.value());
 
   if (const auto result = std::system(command.c_str())) {
     std::cerr << "Error! Build failed with error code: " << result << std::endl;

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -86,10 +86,12 @@ export void process() {
   }
 
   const std::string command =
-      std::format("{} -std={} src/*.cpp -o {}/{}", compiler.value(),
-                  standard.value(), constants::BUILD_DIR, projectName.value());
+      std::format("{} -std={} $(find src -type f \\( -name \"*.cpp\" -o -name "
+                  "\"*.c\" -o -name \"*.cxx\" \\)) -o {}/{}",
+                  compiler.value(), standard.value(), constants::BUILD_DIR,
+                  projectName.value());
 
-  if (auto result = std::system(command.c_str())) {
+  if (const auto result = std::system(command.c_str())) {
     std::cerr << "Error! Build failed with error code: " << result << std::endl;
     return;
   }

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -2,13 +2,73 @@
 
 module;
 
+#include <cstdlib>
+#include <filesystem>
+#include <format>
 #include <iostream>
+#include <optional>
 
 export module build;
+
+/// Comment
+namespace build::constants {
+constexpr std::string_view BUILD_DIR = "build";
+constexpr std::string_view COMPILER = "compiler";
+constexpr std::string_view STANDARD = "standard";
+constexpr std::string_view PROJECT_NAME = "project_name";
+} // namespace build::constants
 
 namespace build {
 
 /// Comment
-export void process() { std::cout << "Test build" << std::endl; }
+void createBuildDirectory() {
+  std::filesystem::create_directory(constants::BUILD_DIR);
+}
+
+/// Comment
+std::optional<std::string> extractConfigValue(std::string_view key) {
+  if (key == "compiler")
+    return "g++";
+  if (key == "project_name")
+    return "newprj";
+  if (key == "standard")
+    return "c++20";
+
+  return std::nullopt;
+}
+
+/// Comment
+export void process() {
+  // TODO: Check if exists
+  createBuildDirectory();
+
+  const auto compiler = extractConfigValue(constants::COMPILER);
+  if (!compiler.has_value()) {
+    std::cerr << "Error! \"compiler\" not provided in nimbus.toml" << std::endl;
+    return;
+  }
+
+  const auto standard = extractConfigValue(constants::STANDARD);
+  if (!standard.has_value()) {
+    std::cerr << "Error! \"standard\" not provided in nimbus.toml" << std::endl;
+    return;
+  }
+
+  const auto projectName = extractConfigValue(constants::PROJECT_NAME);
+  if (!projectName.has_value()) {
+    std::cerr << "Error! \"project_name\" not provided in nimbus.toml"
+              << std::endl;
+    return;
+  }
+
+  const std::string command =
+      std::format("{} -std={} src/*.cpp -o {}/{}", compiler.value(),
+                  standard.value(), constants::BUILD_DIR, projectName.value());
+
+  if (auto result = std::system(command.c_str())) {
+    std::cerr << "Error! Build failed with error code: " << result << std::endl;
+    return;
+  }
+}
 
 } // namespace build

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -7,6 +7,7 @@ module;
 #include <format>
 #include <iostream>
 #include <optional>
+#include <toml.hpp>
 
 export module build;
 
@@ -15,7 +16,11 @@ namespace build::constants {
 constexpr std::string_view BUILD_DIR = "build";
 constexpr std::string_view COMPILER = "compiler";
 constexpr std::string_view STANDARD = "standard";
-constexpr std::string_view PROJECT_NAME = "project_name";
+constexpr std::string_view NAME = "name";
+constexpr std::string_view CONFIG_FILE = "nimbus.toml";
+
+constexpr std::string_view SECTION_BUILD = "build";
+constexpr std::string_view SECTION_PROJECT = "project";
 } // namespace build::constants
 
 namespace build {
@@ -30,13 +35,24 @@ void createBuildDirectory() {
 }
 
 /// Comment
-std::optional<std::string> extractConfigValue(std::string_view key) {
-  if (key == "compiler")
-    return "g++";
-  if (key == "project_name")
-    return "newprj";
-  if (key == "standard")
-    return "c++20";
+std::optional<std::string> extractConfigValue(std::string_view section,
+                                              std::string_view key) {
+  try {
+    auto config = toml::parse(std::string(constants::CONFIG_FILE));
+
+    if (config.contains(std::string(section))) {
+      const auto &sectionTable = toml::find(config, std::string(section));
+      if (sectionTable.contains(std::string(key))) {
+        auto &value =
+            toml::find_or<std::string>(sectionTable, std::string(key), "");
+        if (!value.empty())
+          return value;
+      }
+    }
+  } catch (const toml::exception &e) {
+    std::cerr << "Error! Failed reading nimbus.toml file: " << e.what()
+              << std::endl;
+  }
 
   return std::nullopt;
 }
@@ -45,21 +61,26 @@ std::optional<std::string> extractConfigValue(std::string_view key) {
 export void process() {
   createBuildDirectory();
 
-  const auto compiler = extractConfigValue(constants::COMPILER);
+  const auto compiler =
+      extractConfigValue(constants::SECTION_BUILD, constants::COMPILER);
   if (!compiler.has_value()) {
-    std::cerr << "Error! \"compiler\" not provided in nimbus.toml" << std::endl;
+    std::cerr << "Error! " << constants::COMPILER
+              << " not provided in nimbus.toml" << std::endl;
     return;
   }
 
-  const auto standard = extractConfigValue(constants::STANDARD);
+  const auto standard =
+      extractConfigValue(constants::SECTION_BUILD, constants::STANDARD);
   if (!standard.has_value()) {
-    std::cerr << "Error! \"standard\" not provided in nimbus.toml" << std::endl;
+    std::cerr << "Error! " << constants::STANDARD
+              << " not provided in nimbus.toml" << std::endl;
     return;
   }
 
-  const auto projectName = extractConfigValue(constants::PROJECT_NAME);
+  const auto projectName =
+      extractConfigValue(constants::SECTION_PROJECT, constants::NAME);
   if (!projectName.has_value()) {
-    std::cerr << "Error! \"project_name\" not provided in nimbus.toml"
+    std::cerr << "Error! " << constants::NAME << " not provided in nimbus.toml"
               << std::endl;
     return;
   }

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -78,7 +78,7 @@ bool translateBuildType(std::string &buildType) noexcept {
 }
 
 /// Comment
-std::optional<std::string> constructBuildCommand() {
+std::optional<std::string> constructBuildCommand() noexcept {
   const auto compiler = extractConfigValue(toString(constants::Table::Build),
                                            toString(constants::Key::Compiler));
   if (!compiler.has_value()) {

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -22,6 +22,10 @@ namespace build {
 
 /// Comment
 void createBuildDirectory() {
+  if (std::filesystem::is_directory(constants::BUILD_DIR)) {
+    return;
+  }
+
   std::filesystem::create_directory(constants::BUILD_DIR);
 }
 
@@ -39,7 +43,6 @@ std::optional<std::string> extractConfigValue(std::string_view key) {
 
 /// Comment
 export void process() {
-  // TODO: Check if exists
   createBuildDirectory();
 
   const auto compiler = extractConfigValue(constants::COMPILER);

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -2,44 +2,38 @@
 
 module;
 
+// std
 #include <cstdlib>
 #include <filesystem>
 #include <format>
 #include <iostream>
 #include <optional>
+
+// external
 #include <toml.hpp>
 
+// internal
+#include "../../include/constants/config_toml.hpp"
+#include "../../include/constants/directory.hpp"
+
 export module build;
-
-/// Comment
-namespace build::constants {
-constexpr std::string_view BUILD_DIR = "build";
-constexpr std::string_view SRC_DIR = "src";
-constexpr std::string_view COMPILER = "compiler";
-constexpr std::string_view STANDARD = "standard";
-constexpr std::string_view NAME = "name";
-constexpr std::string_view CONFIG_FILE = "nimbus.toml";
-
-constexpr std::string_view SECTION_BUILD = "build";
-constexpr std::string_view SECTION_PROJECT = "project";
-} // namespace build::constants
 
 namespace build {
 
 /// Comment
 void createBuildDirectory() {
-  if (std::filesystem::is_directory(constants::BUILD_DIR)) {
+  if (std::filesystem::is_directory(toString(constants::Directory::Build))) {
     return;
   }
 
-  std::filesystem::create_directory(constants::BUILD_DIR);
+  std::filesystem::create_directory(toString(constants::Directory::Build));
 }
 
 /// Comment
 std::optional<std::string> extractConfigValue(std::string_view section,
                                               std::string_view key) {
   try {
-    auto config = toml::parse(std::string(constants::CONFIG_FILE));
+    auto config = toml::parse(std::string(constants::ConfigFile));
 
     if (config.contains(std::string(section))) {
       const auto &sectionTable = toml::find(config, std::string(section));
@@ -58,31 +52,34 @@ std::optional<std::string> extractConfigValue(std::string_view section,
   return std::nullopt;
 }
 
+/// Comment example tbl.key
+void logConfigErrorMessage(constants::Table tbl, constants::Key key) {
+  std::cerr << "Error! " << toString(tbl) << "." << toString(key)
+            << " not provided in " << constants::ConfigFile << std::endl;
+}
+
 /// Comment
 export void process() {
   createBuildDirectory();
 
-  const auto compiler =
-      extractConfigValue(constants::SECTION_BUILD, constants::COMPILER);
+  const auto compiler = extractConfigValue(toString(constants::Table::Build),
+                                           toString(constants::Key::Compiler));
   if (!compiler.has_value()) {
-    std::cerr << "Error! " << constants::COMPILER << " not provided in "
-              << constants::CONFIG_FILE << std::endl;
+    logConfigErrorMessage(constants::Table::Build, constants::Key::Compiler);
     return;
   }
 
-  const auto standard =
-      extractConfigValue(constants::SECTION_BUILD, constants::STANDARD);
+  const auto standard = extractConfigValue(toString(constants::Table::Build),
+                                           toString(constants::Key::Standard));
   if (!standard.has_value()) {
-    std::cerr << "Error! " << constants::STANDARD << " not provided in "
-              << constants::CONFIG_FILE << std::endl;
+    logConfigErrorMessage(constants::Table::Build, constants::Key::Standard);
     return;
   }
 
-  const auto projectName =
-      extractConfigValue(constants::SECTION_PROJECT, constants::NAME);
+  const auto projectName = extractConfigValue(
+      toString(constants::Table::Project), toString(constants::Key::Name));
   if (!projectName.has_value()) {
-    std::cerr << "Error! " << constants::NAME << " not provided in "
-              << constants::CONFIG_FILE << std::endl;
+    logConfigErrorMessage(constants::Table::Project, constants::Key::Name);
     return;
   }
 
@@ -90,17 +87,17 @@ export void process() {
       "$(find {} -type f \\( -name \"*.cpp\" -o "
       "-name \"*.c\" -o -name \"*.cxx\" \\))";
 
-  const std::string command =
-      std::format("{} -std={} {} -o {}/{}", compiler.value(), standard.value(),
-                  std::format(findSubcommand, constants::SRC_DIR),
-                  constants::BUILD_DIR, projectName.value());
-
-  std::cout << command << std::endl;
+  const std::string command = std::format(
+      "{} -std={} {} -o {}/{}", compiler.value(), standard.value(),
+      std::format(findSubcommand, toString(constants::Directory::Src)),
+      toString(constants::Directory::Build), projectName.value());
 
   if (const auto result = std::system(command.c_str())) {
     std::cerr << "Error! Build failed with error code: " << result << std::endl;
     return;
   }
+
+  std::cout << "Build finished!" << std::endl;
 }
 
 } // namespace build

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -64,24 +64,24 @@ export void process() {
   const auto compiler =
       extractConfigValue(constants::SECTION_BUILD, constants::COMPILER);
   if (!compiler.has_value()) {
-    std::cerr << "Error! " << constants::COMPILER
-              << " not provided in nimbus.toml" << std::endl;
+    std::cerr << "Error! " << constants::COMPILER << " not provided in "
+              << constants::CONFIG_FILE << std::endl;
     return;
   }
 
   const auto standard =
       extractConfigValue(constants::SECTION_BUILD, constants::STANDARD);
   if (!standard.has_value()) {
-    std::cerr << "Error! " << constants::STANDARD
-              << " not provided in nimbus.toml" << std::endl;
+    std::cerr << "Error! " << constants::STANDARD << " not provided in "
+              << constants::CONFIG_FILE << std::endl;
     return;
   }
 
   const auto projectName =
       extractConfigValue(constants::SECTION_PROJECT, constants::NAME);
   if (!projectName.has_value()) {
-    std::cerr << "Error! " << constants::NAME << " not provided in nimbus.toml"
-              << std::endl;
+    std::cerr << "Error! " << constants::NAME << " not provided in "
+              << constants::CONFIG_FILE << std::endl;
     return;
   }
 

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -14,6 +14,7 @@ export module build;
 /// Comment
 namespace build::constants {
 constexpr std::string_view BUILD_DIR = "build";
+constexpr std::string_view SRC_DIR = "src";
 constexpr std::string_view COMPILER = "compiler";
 constexpr std::string_view STANDARD = "standard";
 constexpr std::string_view NAME = "name";
@@ -85,14 +86,16 @@ export void process() {
     return;
   }
 
-  // char due to '\' constexpr violation
-  constexpr char findSubcommand[] =
-      "$(find src -type f \\( -name \"*.cpp\" -o -name \"*.c\" -o -name "
-      "\"*.cxx\" \\))";
+  constexpr std::string_view findSubcommand =
+      "$(find {} -type f \\( -name \"*.cpp\" -o "
+      "-name \"*.c\" -o -name \"*.cxx\" \\))";
 
   const std::string command =
       std::format("{} -std={} {} -o {}/{}", compiler.value(), standard.value(),
-                  findSubcommand, constants::BUILD_DIR, projectName.value());
+                  std::format(findSubcommand, constants::SRC_DIR),
+                  constants::BUILD_DIR, projectName.value());
+
+  std::cout << command << std::endl;
 
   if (const auto result = std::system(command.c_str())) {
     std::cerr << "Error! Build failed with error code: " << result << std::endl;

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -1,0 +1,14 @@
+/// Comment
+
+module;
+
+#include <iostream>
+
+export module build;
+
+namespace build {
+
+/// Comment
+export void process() { std::cout << "Test build" << std::endl; }
+
+} // namespace build

--- a/src/commands/build.cppm
+++ b/src/commands/build.cppm
@@ -1,4 +1,17 @@
-/// Comment
+/**
+ * @file build.cppm
+ * @brief This module handles the construction and execution of the build
+ * process.
+ *
+ * The `build` module is responsible for orchestrating the project's build
+ * steps, including creating necessary directories, reading configuration values
+ * from the project's `nimbus.toml` file, and executing the compile command.
+ *
+ * Features:
+ * - Create a build directory if it does not exist.
+ * - Extract configuration values for compiler, standard, build type, etc.
+ * - Construct a build command string and execute it.
+ */
 
 module;
 
@@ -19,8 +32,12 @@ module;
 export module build;
 
 namespace build {
-
-/// Comment
+/**
+ * @brief Creates the build directory if it does not already exist.
+ *
+ * Ensures that a dedicated build directory is available for compiled
+ * objects and the final executable.
+ */
 void createBuildDirectory() {
   if (std::filesystem::is_directory(toString(constants::Directory::Build))) {
     return;
@@ -29,14 +46,25 @@ void createBuildDirectory() {
   std::filesystem::create_directory(toString(constants::Directory::Build));
 }
 
-/// Comment
-std::optional<std::string> extractConfigValue(std::string_view section,
+/**
+ * @brief Extracts a configuration value from the project's `nimbus.toml` file.
+ *
+ * Attempts to locate and return the value for the given `table` and `key`
+ * in the configuration file. If the value cannot be found or the file fails
+ * to parse, it returns `std::nullopt`.
+ *
+ * @param table The configuration table name.
+ * @param key The key within the given table.
+ * @return An optional string with the configuration value if found;
+ *         `std::nullopt` otherwise.
+ */
+std::optional<std::string> extractConfigValue(std::string_view table,
                                               std::string_view key) {
   try {
     auto config = toml::parse(std::string(constants::ConfigFile));
 
-    if (config.contains(std::string(section))) {
-      const auto &sectionTable = toml::find(config, std::string(section));
+    if (config.contains(std::string(table))) {
+      const auto &sectionTable = toml::find(config, std::string(table));
       if (sectionTable.contains(std::string(key))) {
         auto &value =
             toml::find_or<std::string>(sectionTable, std::string(key), "");
@@ -52,13 +80,35 @@ std::optional<std::string> extractConfigValue(std::string_view section,
   return std::nullopt;
 }
 
-/// Comment example tbl.key
+/**
+ * @brief Logs a standardized error message for a missing configuration
+ * parameter.
+ *
+ * This function is used to inform the user that a required configuration
+ * parameter (identified by its table and key) is not provided in the
+ * `nimbus.toml` file. It prints a clear error message to `stderr`.
+ *
+ * @param tbl The configuration table name.
+ * @param key The configuration key that is missing.
+ */
 void logConfigErrorMessage(constants::Table tbl, constants::Key key) noexcept {
   std::cerr << "Error! " << toString(tbl) << "." << toString(key)
             << " not provided in " << constants::ConfigFile << std::endl;
 }
 
-/// Comment
+/**
+ * @brief Translates a known build type string into corresponding compiler
+ * flags.
+ *
+ * Given a human-readable build type string (e.g., "Debug", "Release",
+ * "RelWithDebInfo", "MinSizeRel"), this function modifies the input string in
+ * place to contain the appropriate compiler flags.
+ *
+ * @param buildType A reference to the build type string to translate. If
+ * recognized, it is replaced with the corresponding compiler flags.
+ * @return `true` if the build type was recognized and translated, `false`
+ * otherwise.
+ */
 bool translateBuildType(std::string &buildType) noexcept {
   if (buildType == "Debug") {
     buildType = "-g -O0 -DDEBUG";
@@ -77,7 +127,18 @@ bool translateBuildType(std::string &buildType) noexcept {
   }
 }
 
-/// Comment
+/**
+ * @brief Constructs the build command string used to compile the project's
+ * source files.
+ *
+ * Reads required parameters such as the compiler, standard, build type, and
+ * project name from the `nimbus.toml` file. Then, constructs a complete shell
+ * command string that will invoke the compiler with all necessary flags and
+ * include all source files.
+ *
+ * @return An optional string containing the build command if all required
+ * configurations are present and valid, `std::nullopt` otherwise.
+ */
 std::optional<std::string> constructBuildCommand() noexcept {
   const auto compiler = extractConfigValue(toString(constants::Table::Build),
                                            toString(constants::Key::Compiler));
@@ -118,7 +179,16 @@ std::optional<std::string> constructBuildCommand() noexcept {
       projectName.value());
 }
 
-/// Comment
+/**
+ * @brief Executes the provided shell command and reports build success or
+ * failure.
+ *
+ * Uses `std::system` to run the given build command. If the command fails,
+ * prints an error message with the returned status code. Otherwise, indicates
+ * that the build process has finished successfully.
+ *
+ * @param command The shell command to be executed.
+ */
 void executeCommand(const std::string &command) {
   if (const auto result = std::system(command.c_str())) {
     std::cerr << "Error! Build failed with error code: " << result << std::endl;
@@ -128,7 +198,12 @@ void executeCommand(const std::string &command) {
   std::cout << "Build process finished!" << std::endl;
 }
 
-/// Comment
+/**
+ * @brief Orchestrates the build process of the current project.
+ *
+ * Ensures the build directory exists, constructs the build command from
+ * configuration values, and executes it if all required values are present.
+ */
 export void process() {
   createBuildDirectory();
 
@@ -136,5 +211,4 @@ export void process() {
   if (command.has_value())
     executeCommand(command.value());
 }
-
 } // namespace build

--- a/src/commands/init.cppm
+++ b/src/commands/init.cppm
@@ -15,38 +15,17 @@
 
 module;
 
+// std
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <string_view>
 
+// internal
+#include "../../include/constants/config_toml.hpp"
+#include "../../include/constants/directory.hpp"
+
 export module init;
-
-/**
- * @namespace init::constants
- * @brief Contains constants used during project initialization.
- *
- * This namespace encapsulates all the constants required for initializing
- * a project, including directory names, configuration file names, and
- * default content templates. These constants are designed to promote
- * maintainability and consistency across the project initialization process.
- */
-namespace init::constants {
-constexpr std::string_view SRC_DIR = "src";
-constexpr std::string_view INCLUDE_DIR = "include";
-constexpr std::string_view CURRENT_DIR = ".";
-
-constexpr std::string_view CONFIG_FILE = "nimbus.toml";
-constexpr std::string_view CONFIG_FILE_CONTENT =
-    "[project]\n"
-    "name = \"{}\"\n"
-    "version = \"0.1.0\"\n"
-    "authors = [\"Your Name <you@example.com>\"]\n\n"
-    "[build]\n"
-    "compiler = \"clang++\"\n"
-    "standard = \"c++20\"\n"
-    "build_type = \"Debug\"\n";
-} // namespace init::constants
 
 namespace init {
 /**
@@ -64,10 +43,15 @@ void createProjectDirectory(std::string_view projectName) {
  * @param path The base path where the directories will be created.
  */
 void createInternalDirectories(std::string_view path) {
-  std::filesystem::create_directory(
-      std::format("{}/{}", path, constants::SRC_DIR));
-  std::filesystem::create_directory(
-      std::format("{}/{}", path, constants::INCLUDE_DIR));
+  if (!std::filesystem::is_directory(toString(constants::Directory::Src))) {
+    std::filesystem::create_directory(
+        std::format("{}/{}", path, toString(constants::Directory::Src)));
+  }
+
+  if (!std::filesystem::is_directory(toString(constants::Directory::Include))) {
+    std::filesystem::create_directory(
+        std::format("{}/{}", path, toString(constants::Directory::Include)));
+  }
 }
 
 /**
@@ -79,9 +63,9 @@ void createInternalDirectories(std::string_view path) {
  */
 void createConfigurationFile(std::string_view projectName,
                              std::string_view path) {
-  std::ofstream file(std::format("{}/{}", path, constants::CONFIG_FILE));
+  std::ofstream file(std::format("{}/{}", path, constants::ConfigFile));
   if (file.is_open()) {
-    file << std::format(constants::CONFIG_FILE_CONTENT, projectName);
+    file << std::format(constants::getConfigFileDefaults(), projectName);
     file.close();
   }
 }
@@ -98,9 +82,9 @@ void createConfigurationFile(std::string_view projectName,
  */
 export void process(std::string_view projectName) {
   if (projectName.empty()) {
-    createInternalDirectories(constants::CURRENT_DIR);
+    createInternalDirectories(toString(constants::Directory::Current));
     createConfigurationFile(std::filesystem::current_path().filename().string(),
-                            constants::CURRENT_DIR);
+                            toString(constants::Directory::Current));
   } else {
     createProjectDirectory(projectName);
     createInternalDirectories(projectName);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,18 +1,25 @@
 #include <CLI/CLI.hpp>
 
 import init;
+import build;
 
 int main(int argc, char **argv) {
   CLI::App app{"C++ build system and package manager"};
 
   // init command section -- start
-  auto initCmd =
+  const auto initCmd =
       app.add_subcommand("init", "Initialize a new project")->alias("i");
 
   std::string projectName;
   initCmd->add_option("project_name", projectName, "Name of the project");
   initCmd->callback([&]() { init::process(projectName); });
   // init command section -- end
+
+  // build command section -- start
+  app.add_subcommand("build", "Compile the current project")
+      ->alias("b")
+      ->callback([&]() { build::process(); });
+  // build command section -- end
 
   CLI11_PARSE(app, argc, argv);
   if (argc == 1)


### PR DESCRIPTION
This PR implements the `nimbus build` command with alias `b`. This command executes the build process of the project, based on the provided configuration in `nimbus.toml`, currently 3 main configs are read and taken into consideration:

1. compiler
   - clang++
   - g++
2. standard
   - all cpp standards in format c++XY
3. build_type
   - **Debug** _providing a preprocessing macro_ **DEBUG**
   - **Release** _providing a preprocessing macro_ **RELEASE**
   - **RelWithDebInfo** _providing a preprocessing macro_ **RELWITHDEBINFO**
   - **MinSizeRel** _providing a preprocessing macro_ **MINSIZEREL**

Executable is placed inside of the `build` directory, named using the `name` config from `nimbus.toml`

Closes #4 